### PR TITLE
Few fixes

### DIFF
--- a/poll-jenkins.py
+++ b/poll-jenkins.py
@@ -54,7 +54,7 @@ build = None
 while True:
     try:
         build = find_build(job, commit)
-    except exceptions.RequestException:
+    except (exceptions.RequestException, jenkins.JenkinsException):
         pass
     if build:
         break
@@ -68,7 +68,7 @@ while True:
         build = server.get_build_info(job, int(build["id"]))
     except exceptions.RequestException:
         pass
-    if build["result"] is not None:
+    if build["result"] is not None and not build["building"]:
         break
     sleep(10)
 


### PR DESCRIPTION
- Don't collect result until `building` is `false`.
- Don't throw when job does not yet exist