### PR TITLE
Display Jenkins console output in gitlab CI task

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ See the `.gitlab-ci.yml.example` for what you need to add to your `.gitlab-ci.ym
  * `JENKINS_HOST` (optional) - defaults to `https://jenkins.mintel.ad`
  * `MULTIBRANCH_JOB` - path that Jenkins job for the target repository, e.g. `EVERESTUI_jobs/web`
  * `PYTHONHTTPSVERIFY` (optional) - defaults to `0` so no SSL verification occurs so self-signed certificates can be used
+ * `JENKINS_NODEBUG` (optional) - Don't output debug info about the job. Defaults to off to preserve existing behaviour.
+ * `JENKINS_CONSOLE_OUTPUT` (optional) - Display the Jenkins console output. Defaults to off to preserve existing behaviour.
 
 The job then uses the provided variables (including ones GitLab injects) to find which particular job is for this branch (e.g. `EVERESTUI_jobs/web/CFD-4563`) and it then polls the job looking for the latest build for the current commit. Once that is found, it polls the build until it has a result where it will exit with 0 if successful, or 1 otherwise.
 

--- a/poll-jenkins.py
+++ b/poll-jenkins.py
@@ -21,7 +21,7 @@ jenkins_host = os.environ.get("JENKINS_HOST", "https://jenkins.mintel.ad")
 # e.g. EVERESTUI_jobs/web
 multibranch_job = os.environ["MULTIBRANCH_JOB"]
 # control the output
-show_debug_info = os.environ.get("JENKINS_DEBUG", True)
+show_debug_info = not(os.environ.get("JENKINS_NODEBUG", False))
 # show Jenkins console log, eg to parse coverage
 show_console_log = os.environ.get("JENKINS_CONSOLE_OUTPUT", False)
 # e.g. CFD-4563

--- a/poll-jenkins.py
+++ b/poll-jenkins.py
@@ -20,6 +20,10 @@ jenkins_password = os.environ["JENKINS_PASSWORD"]
 jenkins_host = os.environ.get("JENKINS_HOST", "https://jenkins.mintel.ad")
 # e.g. EVERESTUI_jobs/web
 multibranch_job = os.environ["MULTIBRANCH_JOB"]
+# control the output
+show_debug_info = os.environ.get("JENKINS_DEBUG", True)
+# show Jenkins console log, eg to parse coverage
+show_console_log = os.environ.get("JENKINS_CONSOLE_OUTPUT", False)
 # e.g. CFD-4563
 branch = os.environ["CI_COMMIT_REF_NAME"]
 # full commit SHA
@@ -63,9 +67,10 @@ while True:
 print(f"Time to find build {datetime.datetime.now() - start}")
 start = datetime.datetime.now()
 
+build_id = int(build["id"])
 while True:
     try:
-        build = server.get_build_info(job, int(build["id"]))
+        build = server.get_build_info(job, build_id)
     except exceptions.RequestException:
         pass
     if build["result"] is not None and not build["building"]:
@@ -74,6 +79,15 @@ while True:
 
 print(f"Time to finish build {datetime.datetime.now() - start}")
 
+if show_debug_info:
+    pprint(build)
+
+if show_console_log:
+    try:
+        console_log = server.get_build_console_output(job, build_id)
+        print(console_log)
+    except (JenkinsException, exceptions.RequestException):
+        pass
+
 result = build["result"]
-pprint(build)
 exit(0 if result == "SUCCESS" else 1)


### PR DESCRIPTION
Small patch for outputting the Jenkins console log in the gitlab CI task. This allows gitlab to parse the output to find the coverage, because badges are important.
Also add another knob for hiding the build JSON, because its ugly to look at.

New knobs:

 * `JENKINS_NODEBUG`
 * `JENKINS_CONSOLE_OUTPUT`